### PR TITLE
Refact/client and identity_document association

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -319,3 +319,21 @@ databaseChangeLog:
                     - foreignKeyName: client_identity_document_fk
                     - references: identity_document(identity_document_id)
                     - nullable: false
+
+  - changeSet:
+      id: modify client and identity_document association
+      author: Gabriel Oswaldo
+      changes:
+        - dropColumn:
+            tableName: client
+            columnName: identity_document_id
+        - addColumn:
+            tableName: identity_document
+            columns:
+              - column:
+                  name: client_id
+                  type: UUID
+                  constraints:
+                    - foreignKeyName: identity_document_client_fk
+                    - references: client(client_id)
+                    - nullable: false


### PR DESCRIPTION
Refactor in the 'central_register' database the association between 'client' and 'identity_document' tables, since 'identity_document' must have a fk referencing 'client_id' column in the 'client' table, and not the other way around.

- Drop the 'identity_document_id' column in the 'client' table
- Add the 'client_id' column in the identity_document table as a fk referencing 'client_id' in the 'client' table

Task: https://trello.com/c/PEhGbq35