### PR TITLE
fix: insert (POST) client request

### DIFF
--- a/src/main/java/com/matera/cadastrocentral/client/Client.java
+++ b/src/main/java/com/matera/cadastrocentral/client/Client.java
@@ -38,9 +38,4 @@ public class Client {
         this.identityDocumentEntityList = clientDTO.getIdentityDocumentEntityList();
         this.telephoneList = clientDTO.getTelephoneList();
     }
-
-    @PrePersist
-    public void prePersist(){
-        this.clientId = UUID.randomUUID();
-    }
 }

--- a/src/main/java/com/matera/cadastrocentral/client/ClientService.java
+++ b/src/main/java/com/matera/cadastrocentral/client/ClientService.java
@@ -59,14 +59,13 @@ public class ClientService {
             // contains at least one identity document
             if(clientDTO.getIdentityDocumentEntityList() != null &&
                     !clientDTO.getIdentityDocumentEntityList().isEmpty()) {
-                Client client = clientRepository.save(new Client(clientDTO));
+                UUID clientId = UUID.randomUUID();
+                Client client = new Client(clientDTO);
+                client.setClientId(clientId);
                 client.getIdentityDocumentEntityList().forEach(
-                        identityDocumentEntity -> {
-                            identityDocumentEntity.setClient(client);
-                            identityDocumentRepository.save(identityDocumentEntity);
-                        }
+                        identityDocumentEntity -> identityDocumentEntity.setClient(client)
                 );
-                return client;
+                return clientRepository.save(client);
             } else {
                 throw new ResponseStatusException(
                         HttpStatus.BAD_REQUEST,


### PR DESCRIPTION
Fix the insert (POST) client API, that was returning 500 because it was trying to insert a identityDocument without a clientId when it saves the client to the database